### PR TITLE
Add a check for jq

### DIFF
--- a/deploy
+++ b/deploy
@@ -16,6 +16,8 @@ if [[ -a 'fly.toml' ]]; then
     exit 1
 fi
 
+command -v jq >/dev/null || { echo "Please install jq"; exit 1; }
+
 # Generate random app name.
 export app="bridge-$(tr -dc '0-9a-z' </dev/urandom | dd bs=8 count=1 2>/dev/null)"
 echo "If something goes wrong, run 'flyctl apps destroy ${app}' and start again."


### PR DESCRIPTION
Running the script without jq results in a cryptic error:
"[warn] Couldn't parse address ":4163" for ORPort", with
"./deploy: line 33: jq: command not found" buried in the middle of the log.